### PR TITLE
feat: adiciona page de configurações no painel de controle do admin

### DIFF
--- a/mock/admin.ts
+++ b/mock/admin.ts
@@ -1,0 +1,12 @@
+import { UserType } from "../src/domain/enums/UserType";
+import UserDomain from "../src/domain/user/UserDomain";
+
+/**
+ * Mock de um usuário logado para fins de desenvolvimento e testes de UI.
+ */
+export const mockUser = new UserDomain({
+  id: 1,
+  name: "Administrador",
+  username: "admin",
+  type: UserType.ADMIN,
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import AppRoutes from "./routes/AppRoutes";
 import { userSessionStore } from "./store/user/UserSessionStore";
-import { mockUser } from "../mock/user";
+import { mockUser } from "../mock/admin";
 import ScrollToTop from "./commons/components/ScrollToTop";
 
 function App() {

--- a/src/commons/admin/AdminDropdown.tsx
+++ b/src/commons/admin/AdminDropdown.tsx
@@ -44,10 +44,6 @@ const AdminDropdown: React.FC = () => {
             
             <div className="border-t border-slate-100 my-1"></div>
             
-            <button className="w-full text-left px-4 py-3 text-xs font-bold text-slate-600 hover:bg-slate-50 rounded-xl">
-              Perfil de Admin
-            </button>
-            
             <button 
               onClick={handleLogout}
               className="w-full flex items-center gap-3 px-4 py-3 text-xs font-black text-red-500 hover:bg-red-50 rounded-xl transition-all uppercase tracking-tighter"

--- a/src/commons/admin/AdminSidebar.tsx
+++ b/src/commons/admin/AdminSidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FaChartLine, FaRegCalendarCheck, FaLayerGroup, FaUsers, FaCog, FaSignOutAlt, FaRocket } from "react-icons/fa";
 import { useNavigate, useLocation } from "react-router-dom";
 import { userSessionStore } from "../../store/user/UserSessionStore";
+import logoSigex from "../../assets/icons/logo.png";
 
 const AdminSidebar: React.FC = () => {
   const navigate = useNavigate();
@@ -20,7 +21,12 @@ const AdminSidebar: React.FC = () => {
     <aside className="w-96 min-w-[384px] bg-[#1e293b] flex flex-col h-screen sticky top-0 z-[1001] shadow-2xl shrink-0 font-inter">
       <div className="p-10 mb-4 border-b border-white/5">
         <h2 className="text-white font-black text-3xl tracking-tighter flex items-center gap-3 italic uppercase">
-          <FaRocket className="text-brand-blue" /> SIGEX
+          <img
+            src={logoSigex}
+            alt="Logo do SIGEX"
+            className="h-8 w-auto"
+          />
+          SIGEX
         </h2>
       </div>
 

--- a/src/pages/admin/AdminSettingsPage.tsx
+++ b/src/pages/admin/AdminSettingsPage.tsx
@@ -1,0 +1,166 @@
+import { observer } from 'mobx-react-lite';
+import { useState } from 'react';
+import Header from "../../commons/header/Header";
+import AdminSidebar from '../../commons/admin/AdminSidebar';
+import Footer from '../../commons/footer/Footer';
+import Modal from '../../commons/modal/Modal';
+import Toast, { ToastType } from '../../commons/toast/Toast';
+
+const AdminSettingsPage = observer(() => {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const [toast, setToast] = useState<{ type: ToastType; message: string } | null>(null);
+
+  const showToast = (type: ToastType, message: string) => {
+    setToast({ type, message });
+  };
+
+  const handleOpenModal = () => {
+    //mock da senha atual do sistema
+    const systemCurrentPassword = 'admin123';
+
+    if (currentPassword !== systemCurrentPassword) {
+      showToast('error', 'A senha atual está incorreta.');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      showToast('warning', 'A nova senha deve ter no mínimo 8 caracteres.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      showToast('error', 'As senhas não coincidem.');
+      return;
+    }
+
+    if (newPassword === currentPassword) {
+      showToast('info', 'A nova senha deve ser diferente da senha atual.');
+      return;
+    }
+
+    setIsModalOpen(true);
+  };
+
+  const handleConfirmChange = () => {
+    setIsModalOpen(false);
+
+    // TODO adminStore.changePassword(currentPassword, newPassword);
+
+    showToast('success', 'Senha alterada com sucesso.');
+
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+  };
+
+  return (
+    <div className="flex min-h-screen bg-[#f8fafc] w-full font-inter">
+      <AdminSidebar />
+
+      <div className="flex-1 flex flex-col min-w-0">
+        <Header />
+
+        <main className="flex-1 p-10 space-y-10 flex flex-col items-center">
+          <div className="w-full max-w-6xl space-y-10">
+
+            <header>
+              <p className="text-[13px] font-black text-brand-blue uppercase tracking-[0.4em] mb-1">
+                Configurações
+              </p>
+              <h1 className="text-5xl font-black text-[#1e293b] tracking-tighter uppercase leading-none">
+                Segurança
+              </h1>
+            </header>
+
+            <section className="bg-white rounded-2xl shadow-sm p-10 space-y-8 max-w-2xl">
+              <h2 className="text-[12px] font-black text-slate-400 uppercase tracking-[0.3em] italic">
+                Alterar senha do administrador
+              </h2>
+
+              <div className="space-y-6">
+                <input
+                  type="password"
+                  placeholder="Senha atual"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="w-full h-12 rounded-lg border border-slate-200 px-4 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                />
+
+                <input
+                  type="password"
+                  placeholder="Nova senha"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  className="w-full h-12 rounded-lg border border-slate-200 px-4 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                />
+
+                <input
+                  type="password"
+                  placeholder="Confirmar nova senha"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="w-full h-12 rounded-lg border border-slate-200 px-4 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                />
+              </div>
+
+              <div className="flex justify-end pt-4">
+                <button
+                  onClick={handleOpenModal}
+                  className="h-12 px-8 rounded-lg font-bold text-white bg-brand-blue"
+                >
+                  Salvar alterações
+                </button>
+              </div>
+            </section>
+          </div>
+        </main>
+
+        <Footer />
+      </div>
+
+      {/* Modal de confirmação */}
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Confirmar alteração de senha"
+      >
+        <div className="space-y-6">
+          <p className="text-slate-600">
+            Tem certeza que deseja alterar a senha do administrador?
+          </p>
+
+          <div className="flex justify-end gap-4">
+            <button
+              onClick={() => setIsModalOpen(false)}
+              className="h-10 px-6 rounded-lg border border-slate-300 font-semibold"
+            >
+              Cancelar
+            </button>
+
+            <button
+              onClick={handleConfirmChange}
+              className="h-10 px-6 rounded-lg bg-brand-blue text-white font-semibold"
+            >
+              Confirmar
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Toast */}
+      {toast && (
+        <Toast
+          type={toast.type}
+          message={toast.message}
+          onClose={() => setToast(null)}
+        />
+      )}
+    </div>
+  );
+});
+
+export default AdminSettingsPage;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -10,6 +10,7 @@ import BookingRequestPage from "../pages/booking/BookingRequestPage";
 import NotFoundPage from "../pages/notfound/NotFoundPage";
 import ProtectedRoute from "./ProtectedRoute";
 import AdminDashboardPage from "../pages/admin/AdminDashboardPage";
+import AdminSettingsPage from "../pages/admin/AdminSettingsPage";
 import ReservationPage from "../pages/user/UserBookingPage";
 
 const AppRoutes = () => {
@@ -27,6 +28,7 @@ const AppRoutes = () => {
 
       <Route element={<ProtectedRoute />}>
         <Route path="/admin" element={<AdminDashboardPage />} />
+        <Route path="/admin/settings" element={<AdminSettingsPage />} />
         {/* outras rotas do admin aqui */}
       </Route>
     </Routes>


### PR DESCRIPTION
Esse PR close: [configuracoes-admin](https://github.com/ES-2025-2-3/sigex_frontend/issues/39)

- adiciona página de configurações no painel de controle do admin:
     - adiciona seção de alteração de senha do admin.

- remove "perfil do admin" do dropdown de admin e deixa apenas o acesso do painel de controle (assumindo que existe apenas um admin padrão no sistema). 